### PR TITLE
Fix ENOTSUP on macOS

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -92,11 +92,15 @@ async function initializeAdminCode() {
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
   const port = parseInt(process.env.PORT || '5000', 10);
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
-    log(`serving on port ${port}`);
-  });
+  server.listen(
+    {
+      port,
+      host: "0.0.0.0",
+      // reusePort causes ENOTSUP on macOS with Node 24
+      // and isn't needed for this server.
+    },
+    () => {
+      log(`serving on port ${port}`);
+    },
+  );
 })();


### PR DESCRIPTION
## Summary
- remove the `reusePort` option when starting the http server

This solves the `listen ENOTSUP` error that occurs on macOS with Node 24.

## Testing
- `npm run dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68840e4f4a5483288c02a15e27657b4a